### PR TITLE
Add Dockerfile for uv based mcp-scholary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS uv
+
+# Install the project into `/app`
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev --no-editable
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+ 
+COPY --from=uv /root/.local /root/.local
+COPY --from=uv --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# when running the container, add --db-path and a bind mount to the host's db file
+ENTRYPOINT ["mcp-scholarly"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
   ```
 </details>
 
+or if you are using Docker
+
+<details>
+  <summary>Published Docker Servers Configuration</summary>
+  ```
+  "mcpServers": {
+    "mcp-scholarly": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "mcp/scholarly"
+      ]
+    }
+  }
+  ```
+</details>
+
+
 ## Development
 
 ### Building and Publishing


### PR DESCRIPTION
Should we also include a docker image so that users can try running this server without a local copy of uv?

The instructions to run this imply that we would push releases to the public mcp/scholarly repository on dockerhub but only if you think that is useful.