### PR TITLE
Fix issues in building article_string in google_scholar.py

### DIFF
--- a/src/mcp_scholarly/google_scholar.py
+++ b/src/mcp_scholarly/google_scholar.py
@@ -17,13 +17,14 @@ class GoogleScholar:
         results_iter = 0
         for searched_article in search_results:
             bib = searched_article.get('bib', {})
-            title = bib.get('title', None)
-            abstract = bib.get('abstract', None)
-            pub_url = searched_article.get('pub_url', None)
-            article_string = "\n".join([title, abstract, pub_url])
+            title = bib.get('title', 'No title')
+            abstract = bib.get('abstract', 'No abstract available')
+            pub_url = searched_article.get('pub_url', 'No URL available')
+            
+            article_string = f"Title: {title}\nAbstract: {abstract}\nURL: {pub_url}"
             articles.append(article_string)
             results_iter += 1
-            if results_iter > MAX_RESULTS:
+            if results_iter >= MAX_RESULTS:
                 break
         return articles
 


### PR DESCRIPTION
The original code
```
@staticmethod
def _parse_results(search_results):
    articles = []
    results_iter = 0
    for searched_article in search_results:
        bib = searched_article.get('bib', {})
        title = bib.get('title', None)
        abstract = bib.get('abstract', None)
        pub_url = searched_article.get('pub_url', None)
        article_string = "\n".join([title, abstract, pub_url]) <---------------
        articles.append(article_string)
        results_iter += 1
        if results_iter > MAX_RESULTS:
            break
    return articles
```
will raise error if any element in `[title, abstract, pub_url]` is None.

In the new version, the default values are reset to prevent such error.