### PR TITLE
feat(retry): add exponential backoff retry for scholarly searches

### DIFF
--- a/src/mcp_scholarly/arxiv_search.py
+++ b/src/mcp_scholarly/arxiv_search.py
@@ -1,7 +1,31 @@
-import arxiv
+import os
+import sys
+import time
 from typing import List
 
+import arxiv
+
 client = arxiv.Client()
+
+# 指数退避重试配置（与 google_scholar 共用）
+DEFAULT_MAX_RETRIES = 50
+INITIAL_BACKOFF_SEC = 1
+MAX_BACKOFF_SEC = 30
+
+
+def _get_max_retries() -> int:
+    raw = os.environ.get("SCHOLAR_MAX_RETRIES")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_RETRIES
+    try:
+        n = int(raw, 10)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_RETRIES
+    return n if n >= 0 else DEFAULT_MAX_RETRIES
+
+
+def _backoff_delay(attempt: int) -> float:
+    return min(INITIAL_BACKOFF_SEC * (2 ** attempt), MAX_BACKOFF_SEC)
 
 
 class ArxivSearch:
@@ -35,5 +59,28 @@ class ArxivSearch:
         return formatted_results
 
     def search(self, keyword, max_results=10) -> List[str]:
-        results = self.arxiv_search(keyword, max_results)
-        return self._parse_results(results)
+        """
+        搜索 arXiv 论文，失败时指数退避重试。
+        重试上限由环境变量 SCHOLAR_MAX_RETRIES 控制（默认 50）。
+        """
+        max_retries = _get_max_retries()
+        last_error: BaseException | None = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                results = self.arxiv_search(keyword, max_results)
+                return self._parse_results(results)
+            except Exception as error:
+                last_error = error
+                if attempt >= max_retries:
+                    break
+                delay = _backoff_delay(attempt)
+                print(
+                    f"[arxiv_search] attempt {attempt + 1}/{max_retries + 1} "
+                    f"failed ({type(error).__name__}: {error}), "
+                    f"retry in {delay}s",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+
+        raise last_error  # type: ignore[misc]

--- a/src/mcp_scholarly/google_scholar.py
+++ b/src/mcp_scholarly/google_scholar.py
@@ -1,7 +1,35 @@
-from scholarly import scholarly
+import os
+import sys
+import time
 from typing import List
 
+from scholarly import scholarly
+
 MAX_RESULTS = 10
+
+# 指数退避重试配置
+# SCHOLAR_MAX_RETRIES: 最大重试次数（优先读取环境变量，未设置时默认 50）
+# 退避策略：初始 1s，每次连续重试翻倍，上限 30s
+DEFAULT_MAX_RETRIES = 50
+INITIAL_BACKOFF_SEC = 1
+MAX_BACKOFF_SEC = 30
+
+
+def _get_max_retries() -> int:
+    """优先读取环境变量 SCHOLAR_MAX_RETRIES，未设置或非法时返回默认值 50"""
+    raw = os.environ.get("SCHOLAR_MAX_RETRIES")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_RETRIES
+    try:
+        n = int(raw, 10)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_RETRIES
+    return n if n >= 0 else DEFAULT_MAX_RETRIES
+
+
+def _backoff_delay(attempt: int) -> float:
+    """指数退避：初始 1s，每次翻倍，上限 30s"""
+    return min(INITIAL_BACKOFF_SEC * (2 ** attempt), MAX_BACKOFF_SEC)
 
 
 class GoogleScholar:
@@ -29,6 +57,30 @@ class GoogleScholar:
         return articles
 
     def search_pubs(self, keyword) -> List[str]:
-        search_results = self.scholarly.search_pubs(keyword)
-        articles = self._parse_results(search_results)
-        return articles
+        """
+        搜索 Google Scholar 论文，失败时指数退避重试。
+        重试上限由环境变量 SCHOLAR_MAX_RETRIES 控制（默认 50）。
+        """
+        max_retries = _get_max_retries()
+        last_error: BaseException | None = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                search_results = self.scholarly.search_pubs(keyword)
+                articles = self._parse_results(search_results)
+                return articles
+            except Exception as error:
+                last_error = error
+                if attempt >= max_retries:
+                    break
+                delay = _backoff_delay(attempt)
+                print(
+                    f"[google_scholar] attempt {attempt + 1}/{max_retries + 1} "
+                    f"failed ({type(error).__name__}: {error}), "
+                    f"retry in {delay}s",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+
+        # 所有重试耗尽，抛出最后一次的异常
+        raise last_error  # type: ignore[misc]


### PR DESCRIPTION
- Initial backoff 1s, doubles each retry, capped at 30s
- New env var SCHOLAR_MAX_RETRIES (default 50)
- Applied to GoogleScholar.search_pubs and ArxivSearch.search
- Logs each retry attempt to stderr